### PR TITLE
Discord broken link fix

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -24,7 +24,7 @@ const Footer = () => {
       <div className="md:flex md:items-center md:justify-between">
         <div className="grid w-full grid-flow-row grid-cols-3 gap-4 pb-10 lg:grid-cols-8 md:max-w-2xl md:pt-7 md:pr-10 md:pb-0">
           <a
-            href="https://discord.tecommons.org/"
+            href="https://discord.gg/7WhT8ymgqD"
             target="_blank"
             rel="noreferrer"
             className="text-white hover:text-white"

--- a/pages/join.js
+++ b/pages/join.js
@@ -42,7 +42,7 @@ export default class Index extends Component {
               </div>
               <YellowButton
                 text="Connect and Learn"
-                url="https://discord.tecommons.org/"
+                url="https://discord.gg/7WhT8ymgqD"
               />
             </div>
           </div>
@@ -59,7 +59,7 @@ export default class Index extends Component {
               <div className="flex justify-center">
                 <YellowButton
                   text="Join our Discord"
-                  url="https://discord.tecommons.org/"
+                  url="https://discord.gg/7WhT8ymgqD"
                 />
               </div>
             </div>


### PR DESCRIPTION
### Problem
All Discord links that redirected to [discord.tecommons.org](discord.tecommons.org) were broken.

### Fix
Changed all references of [discord.tecommons.org](discord.tecommons.org) to [https://discord.gg/7WhT8ymgqD](https://discord.gg/7WhT8ymgqD).