### PR TITLE
Nitfix for emails already registered for newsletter

### DIFF
--- a/components/NewsletterForm.js
+++ b/components/NewsletterForm.js
@@ -54,7 +54,7 @@ const NewletterForm = () => {
       .then((response) => {
         if (response.status !== 200) {
           if (response.status === 409)
-            setErrorMessage("🤖 Already signed");
+            setErrorMessage("You are already signed");
           setSuccess(false);
           return;
         }

--- a/components/NewsletterForm.js
+++ b/components/NewsletterForm.js
@@ -33,6 +33,7 @@ const NewletterForm = () => {
   const [success, setSuccess] = React.useState(false);
   const [loading, setLoading] = React.useState(false);
   const [finished, setFinished] = React.useState(false);
+  const [errorMessage, setErrorMessage] = React.useState("🤖 Error");
 
   const handleEmailChange = (event) => {
     setEmail(event.target.value);
@@ -52,6 +53,8 @@ const NewletterForm = () => {
     fetch(url, requestOptions)
       .then((response) => {
         if (response.status !== 200) {
+          if (response.status === 409)
+            setErrorMessage("🤖 Already signed");
           setSuccess(false);
           return;
         }
@@ -79,7 +82,7 @@ const NewletterForm = () => {
           value={email}
         />
         <button
-          className="p-4 px-8 font-semibold text-gray-800 uppercase bg-white"
+          className="p-4 px-4 font-semibold text-gray-800 uppercase bg-white"
           type="submit"
         >
           {loading ? (
@@ -88,7 +91,7 @@ const NewletterForm = () => {
             success ? (
               "✅ Done"
             ) : (
-              <span className="text-red-500">🤖 Error</span>
+              <span className="text-red-500">{ errorMessage }</span>
             )
           ) : (
             "Subscribe"


### PR DESCRIPTION
## What changed?
When a user is already registered for the newsletter and they try register once again on the website now notifies the user that they are already signed in.

|   Normal error message |  Already registered error message  |
|---|---|
| <img width="453" alt="image" src="https://user-images.githubusercontent.com/28935185/167467416-fae67563-ca73-4d03-b79d-9993d1e75a9e.png">  | <img width="454" alt="image" src="https://user-images.githubusercontent.com/28935185/167467198-e0e35ea9-078b-4317-bc19-98f305bccce5.png">  |

